### PR TITLE
✨ Add props interpolation

### DIFF
--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -11,7 +11,7 @@ const Button = styled.button`
   border: none;
   border-radius: 4px;
   background: ${(props) =>
-    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
+    props.primary ? 'hsl(270deg 100% 30%)' : 'hsl(180deg 100% 30%)'};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <Button>Static Button</Button>;
+  return <Button primary>Static Button</Button>;
 }
 
 const Button = styled.button`
@@ -10,7 +10,8 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: hsl(270deg 100% 30%);
+  background: ${(props) =>
+    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/styled.js
+++ b/src/styled.js
@@ -16,15 +16,21 @@ import { cache } from './components/StyleRegistry';
 const styled = new Proxy(
   function (Tag) {
     // The original styled function that creates a styled component
-    return (css) => {
+    return (templateStrings, ...interpolatedProps) => {
       return function StyledComponent(props) {
         let collectedStyles = cache();
+
+        // Concatenate the parts of the template string with the interpolated props.
+        const generatedCSS = templateStrings.reduce((acc, current, i) => {
+          const interpolatedValue = interpolatedProps[i]?.(props) || "";
+          return acc + current + interpolatedValue;
+        }, '');
 
         // Using the `useId` hook to generate a unique ID for each styled-component.
         const id = React.useId().replace(/:/g, "");
         const generatedClassName = `styled-${id}`;
 
-        const styleContent = `.${generatedClassName} { ${css} }`;
+        const styleContent = `.${generatedClassName} { ${generatedCSS} }`;
 
         collectedStyles.push(styleContent);
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -22,12 +22,12 @@ const styled = new Proxy(
 
         // Concatenate the parts of the template string with the interpolated props.
         const generatedCSS = templateStrings.reduce((acc, current, i) => {
-          const interpolatedValue = interpolatedProps[i]?.(props) || "";
+          const interpolatedValue = interpolatedProps[i]?.(props) || '';
           return acc + current + interpolatedValue;
         }, '');
 
         // Using the `useId` hook to generate a unique ID for each styled-component.
-        const id = React.useId().replace(/:/g, "");
+        const id = React.useId().replace(/:/g, '');
         const generatedClassName = `styled-${id}`;
 
         const styleContent = `.${generatedClassName} { ${generatedCSS} }`;


### PR DESCRIPTION
## Description
This pull request introduces props interpolation to the `styled` function, enhancing its capabilities to be more aligned with popular styling libraries like `styled-components`. It allows developers to interpolate props directly into their styled components, providing more dynamic and versatile styling options.

## Proposed Changes
- **Props Interpolation**: This pull request enables props interpolation within the `styled` function. You can now use template literals and interpolate props seamlessly into your styles, improving the flexibility of styled components. For example, you can style components based on their props like `background: ${props => props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};`.

- **Updated Examples**: The existing `StaticButton` component has been updated to showcase the new props interpolation feature. It demonstrates how you can style components based on their props directly within the styled component definition.

## More Information
Props interpolation adds a powerful dimension to styling components, allowing for dynamic styles based on component props. Feedback and suggestions are highly encouraged. If you have any ideas or improvements to further enhance this feature, please share them. Collaboration is key to advancing this codebase!
